### PR TITLE
Detect as BNS if room has both BNS and NRVs

### DIFF
--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -100,13 +100,13 @@ class Room(NetatmoBase):
 
         if "OTM" in self.device_types:
             self.climate_type = DeviceType.OTM
-        elif "NRV" in self.device_types:
-            self.climate_type = DeviceType.NRV
         elif "NATherm1" in self.device_types:
             self.climate_type = DeviceType.NATherm1
         elif "BNS" in self.device_types:
             self.climate_type = DeviceType.BNS
             self.features.add("humidity")
+        elif "NRV" in self.device_types:
+            self.climate_type = DeviceType.NRV
         elif "BNTH" in self.device_types:
             self.climate_type = DeviceType.BNTH
 


### PR DESCRIPTION
A room may have both a BNS and one or more NRVs. This situation must be handled as a BNS, not as an NRV.